### PR TITLE
Remove superlative attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 
 ## Thanks
 
-This blog was forked from https://github.com/kippt/jekyll-incorporated. Originally built for
-[sendtoinc.com](https://sendtoinc.com), your workspace for sharing and organizing knowledge.
+This blog was forked from https://github.com/kippt/jekyll-incorporated.
 Original template built by:
 
 **Karri Saarinen**


### PR DESCRIPTION
- No need to reference "what" the original template was for
- Only need to reference the "who" it was from